### PR TITLE
GitHub Actions deprecations are addressed

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: custom-runner
     steps:
-      - uses: GuildDevOps/create-cloudflare-dns-record@v2.1
+      - uses: GuildDevOps/create-cloudflare-dns-record@v3
         with:
           type: "A"
           name: "review.example.com"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,16 @@ jobs:
           token: ${{ secrets.CLOUDFLARE_TOKEN }}
           zone: ${{ secrets.CLOUDFLARE_ZONE }}
 ```
+
 **Use full qualified domain name to update if it exist**
+
+## Outputs
+
+| Field         | Description                                   | Type                            |
+| ------------- | --------------------------------------------- | ------------------------------- |
+| record_id     | Record ID                                     | string                          |
+| name          | Affected domain name                          | string                          |
+| record_status | Whether the record was 'created' or 'updated' | string ('created' \| 'updated') |
 
 ## License
 

--- a/action.yaml
+++ b/action.yaml
@@ -29,7 +29,7 @@ outputs:
   name:
     description: 'Affected domain name'
 runs:
-  using: "node12"
+  using: "node20"
   main: "main.js"
 
 branding:

--- a/action.yaml
+++ b/action.yaml
@@ -27,7 +27,9 @@ outputs:
   record_id:
     description: "Record ID"
   name:
-    description: 'Affected domain name'
+    description: "Affected domain name"
+  record_status:
+    description: "Whether the record was 'created' or 'updated'"
 runs:
   using: "node20"
   main: "main.js"

--- a/main.js
+++ b/main.js
@@ -3,7 +3,6 @@
  * https://github.com/marketplace/actions/cloudflare-create-dns-record
  */
 
-const path = require("path");
 const cp = require("child_process");
 
 const saveOutput = ({ id, name }) => {

--- a/main.js
+++ b/main.js
@@ -5,9 +5,10 @@
 
 const cp = require("child_process");
 
-const saveOutput = ({ id, name }) => {
+const saveOutput = ({ id, name }, status) => {
   console.log(`echo "record_id=${id}" >> $GITHUB_OUTPUT`);
   console.log(`echo "name=${name}" >> $GITHUB_OUTPUT`);
+  console.log(`echo "record_status=${status}" >> $GITHUB_OUTPUT`);
 };
 
 const getCurrentRecordId = () => {
@@ -67,7 +68,7 @@ const createRecord = () => {
     process.exit(1);
   }
 
-  saveOutput(result);
+  saveOutput(result, "created");
 };
 
 const updateRecord = (id) => {
@@ -100,7 +101,7 @@ const updateRecord = (id) => {
     process.exit(1);
   }
 
-  saveOutput(result);
+  saveOutput(result, "updated");
 };
 
 const id = getCurrentRecordId();

--- a/main.js
+++ b/main.js
@@ -6,6 +6,11 @@
 const path = require("path");
 const cp = require("child_process");
 
+const saveOutput = ({ id, name }) => {
+  console.log(`echo "record_id=${id}" >> $GITHUB_OUTPUT`);
+  console.log(`echo "name=${name}" >> $GITHUB_OUTPUT`);
+};
+
 const getCurrentRecordId = () => {
   //https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records
   const { status, stdout } = cp.spawnSync("curl", [
@@ -29,7 +34,7 @@ const getCurrentRecordId = () => {
   const record = result.find((x) => x.name === name);
 
   if (!record) {
-    return null
+    return null;
   }
 
   return record.id;
@@ -63,8 +68,7 @@ const createRecord = () => {
     process.exit(1);
   }
 
-  console.log(`echo "id=${result.id}" >> $GITHUB_ENV`);
-  console.log(`echo "name=${result.name}" >> $GITHUB_ENV`);
+  saveOutput(result);
 };
 
 const updateRecord = (id) => {
@@ -97,9 +101,8 @@ const updateRecord = (id) => {
     process.exit(1);
   }
 
-  console.log(`::set-output name=record_id::${result.id}`);
-  console.log(`::set-output name=name::${result.name}`);
-}
+  saveOutput(result);
+};
 
 const id = getCurrentRecordId();
 if (id) {


### PR DESCRIPTION
Noticed some usage of deprecated GHA features when this action ran on one of our workflows: https://github.com/GuildEducationInc/public-api/actions/runs/9286821960.  After looking into this repo more, the following items are addressed:

- feat!: action now runs on Node 20
- feat: `record_status` output can be used to determine if the record was `created` or `updated`
- fix: `id` output is corrected to `record_id` to match the action yaml file
- fix: all action outputs redirect to `$GITHUB_OUTPUT` instead of `$GITHUB_ENV`
- fix: deprecated usage of `::set-output` is migrated to `>> $GITHUB_OUTPUT`